### PR TITLE
Update the pinned gem versions

### DIFF
--- a/build/build.gemspec
+++ b/build/build.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Michael Hotan"]
   spec.email         = ["michael.hotan@socrata.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = %q{A short summary.}
+  spec.description   = %q{Aa longer description.}
+  spec.homepage      = "https://github.com/socrata-platform/consul-ruby-client"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or

--- a/consul-ruby-client.gemspec
+++ b/consul-ruby-client.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Ruby Client library for communicating with Consul Agents.}
   spec.description   = %q{Consul Thin Client.  Exposes Consul defined interfaces through a very thin abstraction
 layer.}
-  spec.homepage      = 'https://github.com/mhotan-s/consul-ruby-client'
+  spec.homepage      = 'https://github.com/socrata-platform/consul-ruby-client'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
@@ -20,11 +20,12 @@ layer.}
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.7'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '>= 10.0', '< 13'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'simplecov', '~> 0.9'
-  spec.add_development_dependency 'webmock', '~> 1.21'
-  spec.add_dependency 'rest-client', '~> 1.6'
-  spec.add_dependency 'representable', '~> 2.1'
-  spec.add_dependency 'json', '~> 1.8'
+  spec.add_development_dependency 'webmock', '>= 1.21', '< 4'
+  spec.add_dependency 'rest-client', '>= 1.6', '< 3'
+  spec.add_dependency 'representable', '>= 2.1', '< 4'
+  spec.add_dependency 'json', '>= 1.8', '< 3'
+  spec.add_dependency 'multi_json', '~> 1.11'
 end

--- a/lib/consul/client/version.rb
+++ b/lib/consul/client/version.rb
@@ -1,5 +1,5 @@
 module Consul
   module Client
-    VERSION = '0.0.12'
+    VERSION = '0.0.13'
   end
 end


### PR DESCRIPTION
The old versions are starting to cause version conflict explosions when paired
with other applications, e.g. Chef now uses json 2.0.3.